### PR TITLE
docs: Change default refreshInterval to 5m

### DIFF
--- a/docs/provider/pulumi.md
+++ b/docs/provider/pulumi.md
@@ -38,7 +38,7 @@ kind: ExternalSecret
 metadata:
   name: secret
 spec:
-  refreshInterval: 20s
+  refreshInterval: 5m
   secretStoreRef:
     kind: SecretStore
     name: secret-store


### PR DESCRIPTION
## Problem Statement

This PR is updating the default `refreshInterval` to `5m`

## Related Issue

-

## Proposed Changes

-

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
